### PR TITLE
typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 Plugin for `flake8` to warn the developer of the usage of [datetime.utcnow()](https://docs.python.org/3/library/datetime.html#datetime.datetime.utcnow).
 
-The problem with `datetme.utcnow()` is that indeed returns the current timestamp in the UTC timzone but the object is a naive `datetime`, that is doesn't have the `tzinfo` argument set.
+The problem with `datetime.utcnow()` is that indeed returns the current timestamp in the UTC timzone but the object is a naive `datetime`, that is doesn't have the `tzinfo` argument set.
 
 Instead [datetime.now()](https://docs.python.org/3/library/datetime.html#datetime.datetime.utcnow) should be used passing the UTC timezone:
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Corrected a typo in the usage instructions for `datetime.utcnow()`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->